### PR TITLE
Minor refactorization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.2.0-rc.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@alephium/web3": "0.2.0-rc.27",
-        "@alephium/web3-wallet": "0.2.0-rc.27",
+        "@alephium/web3": "0.2.0-rc.33",
+        "@alephium/web3-wallet": "0.2.0-rc.33",
         "@walletconnect/jsonrpc-http-connection": "^1.0.3",
         "@walletconnect/jsonrpc-provider": "^1.0.5",
         "@walletconnect/jsonrpc-types": "^1.0.1",
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@alephium/web3": {
-      "version": "0.2.0-rc.27",
-      "resolved": "https://registry.npmjs.org/@alephium/web3/-/web3-0.2.0-rc.27.tgz",
-      "integrity": "sha512-DH527SUWKqcwtncIF+NsSQqsmlFYZv0B/lqeO5SImrnVj6JN8UVb3/TzbwTeR2wpQ9nvDYD35M95x0Eir7HXbg==",
+      "version": "0.2.0-rc.33",
+      "resolved": "https://registry.npmjs.org/@alephium/web3/-/web3-0.2.0-rc.33.tgz",
+      "integrity": "sha512-Lwvi5hieVvarC5IkIpTHutmBuTMhqN4GOx611KMFKJ7AculqFiX+KVn7/STjxVN5uPB93OaooZBpgBT1LM3ytg==",
       "dependencies": {
         "base-x": "4.0.0",
         "blakejs": "1.2.1",
@@ -82,11 +82,11 @@
       }
     },
     "node_modules/@alephium/web3-wallet": {
-      "version": "0.2.0-rc.27",
-      "resolved": "https://registry.npmjs.org/@alephium/web3-wallet/-/web3-wallet-0.2.0-rc.27.tgz",
-      "integrity": "sha512-8qtKgVCHnXZ0EU2r6W8MRcSJaMeQiXlT5POCo125DA+4gMBipdK4JX7Sf+nBUFC4GN1dIQ/j96rZMyjuRGl84g==",
+      "version": "0.2.0-rc.33",
+      "resolved": "https://registry.npmjs.org/@alephium/web3-wallet/-/web3-wallet-0.2.0-rc.33.tgz",
+      "integrity": "sha512-oUS3aXoyCjwK1Z2Iiveauy7MASW4LL8bHA9l78L7QOXa/rbX2xvbsCl62J3uRELqhlV2A6Bnkdcp4QiEq3dDUA==",
       "dependencies": {
-        "@alephium/web3": "^0.2.0-rc.27",
+        "@alephium/web3": "^0.2.0-rc.33",
         "@types/node": "16.7.8",
         "bip32": "3.1.0",
         "bip39": "3.0.4",
@@ -9776,9 +9776,9 @@
   },
   "dependencies": {
     "@alephium/web3": {
-      "version": "0.2.0-rc.27",
-      "resolved": "https://registry.npmjs.org/@alephium/web3/-/web3-0.2.0-rc.27.tgz",
-      "integrity": "sha512-DH527SUWKqcwtncIF+NsSQqsmlFYZv0B/lqeO5SImrnVj6JN8UVb3/TzbwTeR2wpQ9nvDYD35M95x0Eir7HXbg==",
+      "version": "0.2.0-rc.33",
+      "resolved": "https://registry.npmjs.org/@alephium/web3/-/web3-0.2.0-rc.33.tgz",
+      "integrity": "sha512-Lwvi5hieVvarC5IkIpTHutmBuTMhqN4GOx611KMFKJ7AculqFiX+KVn7/STjxVN5uPB93OaooZBpgBT1LM3ytg==",
       "requires": {
         "base-x": "4.0.0",
         "blakejs": "1.2.1",
@@ -9789,11 +9789,11 @@
       }
     },
     "@alephium/web3-wallet": {
-      "version": "0.2.0-rc.27",
-      "resolved": "https://registry.npmjs.org/@alephium/web3-wallet/-/web3-wallet-0.2.0-rc.27.tgz",
-      "integrity": "sha512-8qtKgVCHnXZ0EU2r6W8MRcSJaMeQiXlT5POCo125DA+4gMBipdK4JX7Sf+nBUFC4GN1dIQ/j96rZMyjuRGl84g==",
+      "version": "0.2.0-rc.33",
+      "resolved": "https://registry.npmjs.org/@alephium/web3-wallet/-/web3-wallet-0.2.0-rc.33.tgz",
+      "integrity": "sha512-oUS3aXoyCjwK1Z2Iiveauy7MASW4LL8bHA9l78L7QOXa/rbX2xvbsCl62J3uRELqhlV2A6Bnkdcp4QiEq3dDUA==",
       "requires": {
-        "@alephium/web3": "^0.2.0-rc.27",
+        "@alephium/web3": "^0.2.0-rc.33",
         "@types/node": "16.7.8",
         "bip32": "3.1.0",
         "bip39": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "lint": "eslint -c '.eslintrc' --fix './src/**/*.ts'"
   },
   "dependencies": {
-    "@alephium/web3": "0.2.0-rc.27",
-    "@alephium/web3-wallet": "0.2.0-rc.27",
+    "@alephium/web3": "0.2.0-rc.33",
+    "@alephium/web3-wallet": "0.2.0-rc.33",
     "@walletconnect/jsonrpc-http-connection": "^1.0.3",
     "@walletconnect/jsonrpc-provider": "^1.0.5",
     "@walletconnect/jsonrpc-types": "^1.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
   groupOfAddress,
   addressFromPublicKey,
   NodeProvider,
+  SubmissionResult,
 } from "@alephium/web3";
 
 import { getChainsFromNamespaces, getAccountsFromNamespaces } from "@walletconnect/utils";
@@ -36,9 +37,9 @@ export const signerMethods = [
   "alph_getSelectedAccount",
   "alph_signTransferTx",
   "alph_signAndSubmitTransferTx",
-  "alph_signContractCreationTx",
+  "alph_signDeployContractTx",
   "alph_signAndSubmitDeployContractTx",
-  "alph_signScriptTx",
+  "alph_signExecuteScriptTx",
   "alph_signAndSubmitExecuteScriptTx",
   "alph_signUnsignedTx",
   "alph_signHexString",
@@ -59,13 +60,25 @@ interface SignerMethodsTable extends Record<SignerMethods, { params: any; result
     params: SignTransferTxParams;
     result: SignTransferTxResult;
   };
-  alph_signContractCreationTx: {
+  alph_signAndSubmitTransferTx: {
+    params: SignTransferTxParams;
+    result: SubmissionResult
+  };
+  alph_signDeployContractTx: {
     params: SignDeployContractTxParams;
     result: SignDeployContractTxResult;
   };
-  alph_signScriptTx: {
+  alph_signAndSubmitDeployContractTx: {
+    params: SignDeployContractTxParams;
+    result: SubmissionResult
+  };
+  alph_signExecuteScriptTx: {
     params: SignExecuteScriptTxParams;
     result: SignExecuteScriptTxResult;
+  };
+  alph_signAndSubmitExecuteScriptTx: {
+    params: SignExecuteScriptTxParams;
+    result: SubmissionResult
   };
   alph_signUnsignedTx: {
     params: SignUnsignedTxParams;
@@ -210,16 +223,32 @@ class WalletConnectProvider extends SignerProvider {
     return this.typedRequest("alph_signTransferTx", params);
   }
 
+  public async signAndSubmitTransferTx(params: SignTransferTxParams): Promise<SubmissionResult> {
+    return this.typedRequest("alph_signAndSubmitTransferTx", params);
+  }
+
   public async signDeployContractTx(
     params: SignDeployContractTxParams,
   ): Promise<SignDeployContractTxResult> {
-    return this.typedRequest("alph_signContractCreationTx", params);
+    return this.typedRequest("alph_signDeployContractTx", params);
+  }
+
+  public async signAndSubmitDeployContractTx(
+    params: SignDeployContractTxParams,
+  ): Promise<SubmissionResult> {
+    return this.typedRequest("alph_signAndSubmitDeployContractTx", params);
   }
 
   public async signExecuteScriptTx(
     params: SignExecuteScriptTxParams,
   ): Promise<SignExecuteScriptTxResult> {
-    return this.typedRequest("alph_signScriptTx", params);
+    return this.typedRequest("alph_signExecuteScriptTx", params);
+  }
+
+  public async signAndSubmitExecuteScriptTx(
+    params: SignExecuteScriptTxParams,
+  ): Promise<SubmissionResult> {
+    return this.typedRequest("alph_signAndSubmitExecuteScriptTx", params);
   }
 
   public async signUnsignedTx(params: SignUnsignedTxParams): Promise<SignUnsignedTxResult> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import {
 import {
   SignerProvider,
   Account,
-  GetAccountsResult,
   SignTransferTxParams,
   SignTransferTxResult,
   SignDeployContractTxParams,
@@ -25,6 +24,7 @@ import {
   SignMessageResult,
   groupOfAddress,
   addressFromPublicKey,
+  NodeProvider,
 } from "@alephium/web3";
 
 import { getChainsFromNamespaces, getAccountsFromNamespaces } from "@walletconnect/utils";
@@ -33,7 +33,7 @@ import { getChainsFromNamespaces, getAccountsFromNamespaces } from "@walletconne
 // 1. the wallet client could potentially submit the signed transaction.
 // 2. `alph_signUnsignedTx` can be used for complicated transactions (e.g. multisig).
 export const signerMethods = [
-  "alph_getAccounts",
+  "alph_getSelectedAccount",
   "alph_signTransferTx",
   "alph_signContractCreationTx",
   "alph_signScriptTx",
@@ -45,12 +45,12 @@ type SignerMethodsTuple = typeof signerMethods;
 type SignerMethods = SignerMethodsTuple[number];
 
 export type NetworkId = number
-export type ChainGroup = number
+export type ChainGroup = number | undefined
 
 interface SignerMethodsTable extends Record<SignerMethods, { params: any; result: any }> {
-  alph_getAccounts: {
+  alph_getSelectedAccount: {
     params: undefined;
-    result: GetAccountsResult;
+    result: Account;
   };
   alph_signTransferTx: {
     params: SignTransferTxParams;
@@ -85,7 +85,7 @@ export const PROVIDER_EVENTS = {
   disconnect: "disconnect",
   displayUri: "displayUri",
   networkChanged: "networkChanged",
-  accountsChanged: "accountsChanged",
+  accountChanged: "accountChanged",
 };
 
 export interface ChainInfo {
@@ -93,41 +93,47 @@ export interface ChainInfo {
   chainGroup: ChainGroup;
 }
 
-export type PermittedChainGroups = Record<NetworkId, ChainGroup[]>
-
 export const ALEPHIUM_NAMESPACE = "alephium";
 
 export interface WalletConnectProviderOptions {
-  permittedChains: ChainInfo[];
+  networkId: number;
+  chainGroup: number;
+  nodeUrl?: string;
+  nodeApiKey?: string;
   methods?: string[];
   client?: SignerConnectionClientOpts;
 }
 
-class WalletConnectProvider implements SignerProvider {
+class WalletConnectProvider extends SignerProvider {
   public events: any = new EventEmitter();
+  public nodeProvider: NodeProvider | undefined = undefined;
+
   public networkId: number;
-  public permittedChainGroups: PermittedChainGroups;
+  public chainGroup: ChainGroup;
   public methods = signerMethods;
 
-  // Wallet may return accounts from chains not defined in the proposal
-  public chains: string[] = [];
-  public accounts: Account[] = [];
+  public account: Account | undefined = undefined;
 
   public signer: JsonRpcProvider;
 
-  get permittedChains(): string[] {
-    return Object.entries(this.permittedChainGroups).flatMap(([networkId, chainGroups]) => {
-      return chainGroups.map((chainGroup) => formatChain(+networkId, chainGroup));
-    });
+  public getSelectedAccount(): Promise<Account> {
+    if (this.account === undefined) {
+      throw Error("There is no selected account.");
+    }
+    return Promise.resolve(this.account);
+  }
+
+  private get permittedChain(): string {
+    return formatChain(this.networkId, this.chainGroup);
   }
 
   constructor(opts: WalletConnectProviderOptions) {
-    if (opts.permittedChains.length === 0) {
-      throw new Error(`No permittedChains`);
-    }
+    super();
 
-    this.networkId = opts.permittedChains[0].networkId;
-    this.permittedChainGroups = getPermittedChainGroups(opts.permittedChains);
+    this.networkId = opts.networkId;
+    this.chainGroup = opts.chainGroup;
+    this.nodeProvider = opts.nodeUrl === undefined ? undefined : new NodeProvider(opts.nodeUrl, opts.nodeApiKey);
+
     this.methods = opts.methods ? [...opts.methods, ...this.methods] : this.methods;
     this.signer = this.setSignerProvider(opts.client);
     this.registerEventListeners();
@@ -135,34 +141,25 @@ class WalletConnectProvider implements SignerProvider {
 
   // The provider only supports signer methods. The other requests should use Alephium Rest API.
   public async request<T = unknown>(args: RequestArguments): Promise<T> {
-    if (args.method === "alph_getAccounts") {
-      return this.accounts as any;
+    if (args.method === "alph_getSelectedAccount") {
+      return this.account as any;
     }
     if (this.methods.includes(args.method)) {
       const signerAddress = args.params?.signerAddress;
       if (typeof signerAddress === "undefined") {
         throw new Error("Cannot request without signerAddress");
       }
-      const signerAccount = this.accounts.find(
-        account => account.address === args.params.signerAddress,
-      );
-      if (typeof signerAccount === "undefined") {
-        throw new Error(`Unknown signer address ${args.params.signerAddress}`);
+      const selectedAccount = await this.getSelectedAccount();
+      if (signerAddress !== selectedAccount.address) {
+        throw new Error(`Invalid signer address ${args.params.signerAddress}`);
       }
-      return this.signer.request(args, {
-        chainId: getPermittedChainId(
-          this.networkId,
-          signerAccount.group,
-          this.permittedChainGroups,
-        ),
-      });
+      return this.signer.request(args, { chainId: this.permittedChain });
     }
     return Promise.reject(new Error(`Invalid method was passed ${args.method}`));
   }
 
-  public async connect(): Promise<GetAccountsResult> {
+  public async connect(): Promise<void> {
     await this.signer.connect();
-    return this.accounts;
   }
 
   get connected(): boolean {
@@ -197,7 +194,7 @@ class WalletConnectProvider implements SignerProvider {
 
   private typedRequest<T extends SignerMethods>(
     method: T,
-    params: MethodParams<T>,
+    params: MethodParams<T>
   ): Promise<MethodResult<T>> {
     return this.request({ method, params });
   }
@@ -234,6 +231,10 @@ class WalletConnectProvider implements SignerProvider {
     return this.typedRequest("alph_signMessage", params);
   }
 
+  public async signRaw(signerAddress: string, hexString: string): Promise<string> {
+    throw Error("Function `signRaw` is not supported");
+  }
+
   // ---------- Private ----------------------------------------------- //
   private registerEventListeners() {
     this.signer.on("connect", async () => {
@@ -264,7 +265,7 @@ class WalletConnectProvider implements SignerProvider {
       SIGNER_EVENTS.event,
       (params: any) => {
         const { event } = params;
-        if (event.name === PROVIDER_EVENTS.accountsChanged) {
+        if (event.name === PROVIDER_EVENTS.accountChanged) {
           this.setAccounts(event.data);
         } else if (event.name === PROVIDER_EVENTS.networkChanged) {
           this.networkId = event.data;
@@ -283,9 +284,9 @@ class WalletConnectProvider implements SignerProvider {
       client,
       requiredNamespaces: {
         alephium: {
-          chains: this.permittedChains,
+          chains: [this.permittedChain],
           methods: this.methods,
-          events: ["chainChanged", "accountsChanged", "networkChanged"],
+          events: ["accountsChanged"],
         },
       },
     });
@@ -308,14 +309,8 @@ class WalletConnectProvider implements SignerProvider {
   }
 
   private setChain(chains: string[]) {
-    if (!this.sameChains(chains, this.chains)) {
-      const chainInfos = chains.map((chain) => {
-        const [networkId, chainGroup] = parseChain(chain);
-        return { networkId, chainGroup };
-      });
-
-      this.permittedChainGroups = getPermittedChainGroups(chainInfos);
-      this.chains = chains;
+    if (!this.sameChains(chains, [this.permittedChain])) {
+      throw Error("Network or chain group has changed");
     }
   }
 
@@ -336,18 +331,17 @@ class WalletConnectProvider implements SignerProvider {
       this.lastSetAccounts = parsedAccounts;
     }
 
-    const permittedGroups = this.permittedChainGroups[this.networkId];
-    const newAccounts = parsedAccounts
-      .filter(account =>
-        permittedGroups.includes(-1) || permittedGroups.includes(account.group),
-      )
-      .filter((value, index, array) =>
-        array.findIndex(v => (v.address === value.address)) === index,
-      );
-    if (newAccounts.length !== 0 && !this.sameAccounts(newAccounts, this.accounts)) {
-      this.accounts = newAccounts;
-      this.events.emit(PROVIDER_EVENTS.accountsChanged, newAccounts);
+    if (parsedAccounts.length !== 1) {
+      throw Error(`The WC provider does not supports multiple accounts`);
     }
+
+    const newAccount = parsedAccounts[0];
+    if (!isCompatibleChainGroup(newAccount, this.chainGroup)) {
+      throw Error(`The new account belongs to an unexpected chain group`);
+    }
+
+    this.account = newAccount;
+    this.events.emit(PROVIDER_EVENTS.accountChanged, newAccount);
   }
 }
 
@@ -355,14 +349,25 @@ export function isCompatibleChain(chain: string): boolean {
   return chain.startsWith(`${ALEPHIUM_NAMESPACE}:`);
 }
 
-export function formatChain(networkId: number, chainGroup: number): string {
-  return `${ALEPHIUM_NAMESPACE}:${networkId}/${chainGroup}`;
+export function isCompatibleChainGroup(account: Account, expectedChainGroup?: ChainGroup): boolean {
+  return expectedChainGroup === undefined || expectedChainGroup === account.group;
 }
 
-export function parseChain(chainString: string): [number, number] {
+export function formatChain(networkId: number, chainGroup: ChainGroup): string {
+  if (chainGroup !== undefined && chainGroup < 0) {
+    throw Error("Chain group in provider needs to be either undefined or non-negative");
+  }
+  const chainGroupEncoded = chainGroup !== undefined ? chainGroup : -1;
+  return `${ALEPHIUM_NAMESPACE}:${networkId}/${chainGroupEncoded}`;
+}
+
+export function parseChain(chainString: string): [NetworkId, ChainGroup] {
   const [_namespace, networkId, chainGroup] = chainString.replace(/\//g, ":").split(":");
   const chainGroupDecoded = parseInt(chainGroup, 10);
-  return [parseInt(networkId, 10), chainGroupDecoded];
+  if (chainGroupDecoded < -1) {
+    throw Error("Chain group in protocol needs to be either -1 or non-negative");
+  }
+  return [parseInt(networkId, 10), chainGroupDecoded === -1 ? undefined : chainGroupDecoded];
 }
 
 export function formatAccount(permittedChain: string, account: Account): string {
@@ -374,46 +379,6 @@ export function parseAccount(account: string): Account {
   const address = addressFromPublicKey(publicKey);
   const group = groupOfAddress(address);
   return { address, group, publicKey };
-}
-
-export function getPermittedChainGroups(infos: ChainInfo[]): PermittedChainGroups {
-  return infos.reduce((acc, info) => {
-    const networkId = info.networkId;
-    const chainGroup = info.chainGroup;
-    acc[networkId] = acc[networkId] || [];
-
-    if (acc[networkId].includes(-1)) {
-      return acc;
-    }
-
-    if (chainGroup === -1) {
-      acc[networkId] = [-1];
-    } else if (!acc[networkId].includes(chainGroup)) {
-      acc[networkId].push(chainGroup);
-    }
-    return acc;
-  }, Object.create({}));
-}
-
-export function getPermittedChainId(
-  networkId: NetworkId,
-  chainGroup: ChainGroup,
-  permittedChainGroups?: PermittedChainGroups,
-): string | undefined {
-  const chainGroups = permittedChainGroups?.[networkId];
-  if (chainGroups === undefined) {
-    return undefined;
-  }
-
-  if (chainGroups.includes(-1)) {
-    return formatChain(networkId, -1);
-  }
-
-  if (chainGroups.includes(chainGroup)) {
-    return formatChain(networkId, chainGroup);
-  }
-
-  return undefined;
 }
 
 export default WalletConnectProvider;

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,15 +374,6 @@ export function isCompatibleChain(chain: string): boolean {
   return chain.startsWith(`${ALEPHIUM_NAMESPACE}:`);
 }
 
-export function isCompatibleWithPermittedGroups(group: ChainGroup, permittedGroups: ChainGroup[]): boolean {
-  for (const permittedGroup of permittedGroups) {
-    if (isCompatibleChainGroup(group, permittedGroup)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 export function isCompatibleChainGroup(group: ChainGroup, expectedChainGroup?: ChainGroup): boolean {
   return expectedChainGroup === undefined || expectedChainGroup === group;
 }
@@ -413,30 +404,6 @@ export function parseAccount(account: string): Account {
   const address = addressFromPublicKey(publicKey);
   const group = groupOfAddress(address);
   return { address, group, publicKey };
-}
-
-export function getPermittedChainGroups(chains: string[]): Record<NetworkId, ChainGroup[]> {
-  const infos = chains.map((chain) => {
-    const [networkId, chainGroup] = parseChain(chain)
-    return { networkId, chainGroup }
-  })
-
-  return infos.reduce((acc, info) => {
-    const networkId = info.networkId;
-    const chainGroup = info.chainGroup;
-    acc[networkId] = acc[networkId] || [];
-
-    if (acc[networkId].includes(undefined)) {
-      return acc;
-    }
-
-    if (chainGroup === undefined) {
-      acc[networkId] = [undefined];
-    } else if (!acc[networkId].includes(chainGroup)) {
-      acc[networkId].push(chainGroup);
-    }
-    return acc;
-  }, Object.create({}));
 }
 
 export default WalletConnectProvider;

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ export const ALEPHIUM_NAMESPACE = "alephium";
 
 export interface WalletConnectProviderOptions {
   networkId: number;
-  chainGroup: number;
+  chainGroup: ChainGroup;
   nodeUrl?: string;
   nodeApiKey?: string;
   methods?: string[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,13 +132,6 @@ class WalletConnectProvider extends SignerProvider {
 
   public signer: JsonRpcProvider;
 
-  public get selectedAccountPromise(): Promise<Account> {
-    if (this.account === undefined) {
-      throw Error("There is no selected account.");
-    }
-    return Promise.resolve(this.account);
-  }
-
   private get permittedChain(): string {
     return formatChain(this.networkId, this.chainGroup);
   }
@@ -158,7 +151,7 @@ class WalletConnectProvider extends SignerProvider {
   // The provider only supports signer methods. The other requests should use Alephium Rest API.
   public async request<T = unknown>(args: RequestArguments): Promise<T> {
     if (args.method === "alph_getSelectedAccount") {
-      return this.account as any;
+      return Promise.resolve(this.account as T);
     }
     if (this.methods.includes(args.method)) {
       const signerAddress = args.params?.signerAddress;
@@ -384,10 +377,10 @@ export function isCompatibleChain(chain: string): boolean {
 export function isCompatibleWithPermittedGroups(group: ChainGroup, permittedGroups: ChainGroup[]): boolean {
   for (const permittedGroup of permittedGroups) {
     if (isCompatibleChainGroup(group, permittedGroup)) {
-      return true
+      return true;
     }
   }
-  return false
+  return false;
 }
 
 export function isCompatibleChainGroup(group: ChainGroup, expectedChainGroup?: ChainGroup): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -390,7 +390,12 @@ export function parseAccount(account: string): Account {
   return { address, group, publicKey };
 }
 
-export function getPermittedChainGroups(infos: ChainInfo[]): Record<NetworkId, ChainGroup[]> {
+export function getPermittedChainGroups(chains: string[]): Record<NetworkId, ChainGroup[]> {
+  const infos = chains.map((chain) => {
+    const [networkId, chainGroup] = parseChain(chain)
+    return { networkId, chainGroup }
+  })
+
   return infos.reduce((acc, info) => {
     const networkId = info.networkId;
     const chainGroup = info.chainGroup;
@@ -400,7 +405,7 @@ export function getPermittedChainGroups(infos: ChainInfo[]): Record<NetworkId, C
       return acc;
     }
 
-    if (chainGroup === -1) {
+    if (chainGroup === undefined) {
       acc[networkId] = [undefined];
     } else if (!acc[networkId].includes(chainGroup)) {
       acc[networkId].push(chainGroup);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,11 @@ import { getChainsFromNamespaces, getAccountsFromNamespaces } from "@walletconne
 export const signerMethods = [
   "alph_getSelectedAccount",
   "alph_signTransferTx",
+  "alph_signAndSubmitTransferTx",
   "alph_signContractCreationTx",
+  "alph_signAndSubmitDeployContractTx",
   "alph_signScriptTx",
+  "alph_signAndSubmitExecuteScriptTx",
   "alph_signUnsignedTx",
   "alph_signHexString",
   "alph_signMessage",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -123,10 +123,12 @@ describe("Unit tests", function() {
   it("test formatChain & parseChain", () => {
     expect(formatChain(4, expectedChainGroup0)).to.eql("alephium:4/2");
     expect(formatChain(4, expectedChainGroup1)).to.eql("alephium:4/1");
-    expect(formatChain(4, -1)).to.eql("alephium:4/-1");
+    expect(formatChain(4, undefined)).to.eql("alephium:4/-1");
+    expect(() => formatChain(4, -1)).to.throw();
     expect(parseChain("alephium:4/2")).to.eql([4, 2]);
     expect(parseChain("alephium:4/1")).to.eql([4, 1]);
-    expect(parseChain("alephium:4/-1")).to.eql([4, -1]);
+    expect(parseChain("alephium:4/-1")).to.eql([4, undefined]);
+    expect(() => parseChain("alephium:4/-2")).to.throw();
   });
 
   it("test getPermittedChainGroups", () => {
@@ -134,7 +136,7 @@ describe("Unit tests", function() {
     expect(getPermittedChainGroups([
       { networkId: 4, chainGroup: 1 },
       { networkId: 4, chainGroup: 2 },
-      { networkId: 4, chainGroup: -1 },
+      { networkId: 4, chainGroup: undefined },
       { networkId: 1, chainGroup: 1 },
       { networkId: 1, chainGroup: 2 },
     ])).to.eql({

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 
 import WalletConnectProvider, {
   formatChain,
+  getPermittedChainGroups,
   parseChain,
 } from "../src/index";
 import { WalletClient } from "./shared";
@@ -124,6 +125,36 @@ describe("Unit tests", function() {
     expect(parseChain("alephium:4/1")).to.eql([4, 1]);
     expect(parseChain("alephium:4/-1")).to.eql([4, undefined]);
     expect(() => parseChain("alephium:4/-2")).to.throw();
+  });
+
+  it("test getPermittedChainGroups", () => {
+    expect(getPermittedChainGroups([])).to.eql({})
+    expect(getPermittedChainGroups([
+      "alephium/4:1",
+      "alephium/4:2",
+      "alephium/4:-1",
+      "alephium/1:1",
+      "alephium/1:2",
+    ])).to.eql({
+      1: [1, 2],
+      4: [undefined]
+    })
+    expect(getPermittedChainGroups([
+      "alephium/4:-1",
+      "alephium/4:1",
+      "alephium/2:2",
+      "alephium/2:2",
+      "alephium/2:3",
+      "alephium/4:-1",
+      "alephium/1:1",
+      "alephium/1:1",
+      "alephium/1:2",
+      "alephium/1:-1",
+    ])).to.eql({
+      1: [undefined],
+      2: [2, 3],
+      4: [undefined]
+    })
   });
 });
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3,7 +3,6 @@ import { expect } from "chai";
 
 import WalletConnectProvider, {
   formatChain,
-  getPermittedChainGroups,
   parseChain,
 } from "../src/index";
 import { WalletClient } from "./shared";
@@ -121,36 +120,6 @@ describe("Unit tests", function() {
     expect(parseChain("alephium:4/1")).to.eql([4, 1]);
     expect(parseChain("alephium:4/-1")).to.eql([4, undefined]);
     expect(() => parseChain("alephium:4/-2")).to.throw();
-  });
-
-  it("test getPermittedChainGroups", () => {
-    expect(getPermittedChainGroups([])).to.eql({})
-    expect(getPermittedChainGroups([
-      "alephium/4:1",
-      "alephium/4:2",
-      "alephium/4:-1",
-      "alephium/1:1",
-      "alephium/1:2",
-    ])).to.eql({
-      1: [1, 2],
-      4: [undefined]
-    })
-    expect(getPermittedChainGroups([
-      "alephium/4:-1",
-      "alephium/4:1",
-      "alephium/2:2",
-      "alephium/2:2",
-      "alephium/2:3",
-      "alephium/4:-1",
-      "alephium/1:1",
-      "alephium/1:1",
-      "alephium/1:2",
-      "alephium/1:-1",
-    ])).to.eql({
-      1: [undefined],
-      2: [2, 3],
-      4: [undefined]
-    })
   });
 });
 

--- a/test/shared/WalletClient.ts
+++ b/test/shared/WalletClient.ts
@@ -300,22 +300,22 @@ export class WalletClient {
                 (request.params as any) as SignTransferTxParams,
               );
               break;
-            case "alph_signContractCreationTx":
+            case "alph_signDeployContractTx":
               result = await this.signer.signDeployContractTx(
                 (request.params as any) as SignDeployContractTxParams,
               );
               break;
-            case "alph_signAndSubmitContractCreationTx":
+            case "alph_signAndSubmitDeployContractTx":
               result = await this.signer.signAndSubmitDeployContractTx(
                 (request.params as any) as SignDeployContractTxParams,
               );
               break;
-            case "alph_signScriptTx":
+            case "alph_signExecuteScriptTx":
               result = await this.signer.signExecuteScriptTx(
                 (request.params as any) as SignExecuteScriptTxParams,
               );
               break;
-            case "alph_signAndSubmitScriptTx":
+            case "alph_signAndSubmitExecuteScriptTx":
               result = await this.signer.signAndSubmitExecuteScriptTx(
                 (request.params as any) as SignExecuteScriptTxParams,
               );

--- a/test/shared/WalletClient.ts
+++ b/test/shared/WalletClient.ts
@@ -157,7 +157,7 @@ export class WalletClient {
     return wallet;
   }
 
-  private async updateSession() {
+  private async updateSession(chainId: string) {
     if (typeof this.client === "undefined") return;
     if (typeof this.topic === "undefined") return;
     if (typeof this.namespace === "undefined") return;
@@ -165,13 +165,16 @@ export class WalletClient {
     await this.client.update({
       topic: this.topic,
       namespaces: {
-        "alephium": this.namespace
+        "alephium": {
+          ...this.namespace,
+          accounts: [`${chainId}:${this.account.publicKey}`]
+        }
       }
     });
   }
 
   private async updateAccounts(chainId: string) {
-    await this.updateSession();
+    await this.updateSession(chainId);
     await this.emitAccountsChangedEvent(chainId);
   }
 
@@ -246,12 +249,7 @@ export class WalletClient {
         this.namespace = {
           methods: requiredAlephiumNamespace.methods,
           events: requiredAlephiumNamespace.events,
-          accounts: [this.chainAccount(requiredAlephiumNamespace.chains)],
-          extension: requiredAlephiumNamespace.extension?.map((ext) => ({
-            methods: ext.methods,
-            events: ext.events,
-            accounts: [this.chainAccount(ext.chains)]
-          }))
+          accounts: [this.chainAccount(requiredAlephiumNamespace.chains)]
         }
 
         const namespaces = { "alephium": this.namespace }
@@ -297,13 +295,28 @@ export class WalletClient {
                 (request.params as any) as SignTransferTxParams,
               );
               break;
+            case "alph_signAndSubmitTransferTx":
+              result = await this.signer.signAndSubmitTransferTx(
+                (request.params as any) as SignTransferTxParams,
+              );
+              break;
             case "alph_signContractCreationTx":
               result = await this.signer.signDeployContractTx(
                 (request.params as any) as SignDeployContractTxParams,
               );
               break;
+            case "alph_signAndSubmitContractCreationTx":
+              result = await this.signer.signAndSubmitDeployContractTx(
+                (request.params as any) as SignDeployContractTxParams,
+              );
+              break;
             case "alph_signScriptTx":
               result = await this.signer.signExecuteScriptTx(
+                (request.params as any) as SignExecuteScriptTxParams,
+              );
+              break;
+            case "alph_signAndSubmitScriptTx":
+              result = await this.signer.signAndSubmitExecuteScriptTx(
                 (request.params as any) as SignExecuteScriptTxParams,
               );
               break;

--- a/test/shared/WalletClient.ts
+++ b/test/shared/WalletClient.ts
@@ -234,12 +234,7 @@ export class WalletClient {
           throw new Error(`No chain is permitted in ${ALEPHIUM_NAMESPACE} namespace during session proposal`);
         }
 
-        const chainInfos = requiredChains.map((requiredChain) => {
-          const [networkId, chainGroup] = parseChain(requiredChain)
-          return { networkId, chainGroup }
-        })
-
-        const permittedChainGroups = getPermittedChainGroups(chainInfos)
+        const permittedChainGroups = getPermittedChainGroups(requiredChains)
         const networks = Object.keys(permittedChainGroups)
         if (networks.length !== 1) {
           throw Error(`WC Provider can only propose session with single networks, but ${networks} are detected`)


### PR DESCRIPTION
This PR tries to make the WC provider consistent the following design:

- WC provider could initialize a session with a namespace defining the permitted network and chain group, only one network would be allowed.
- WC client (desktop wallet, mobile wallet) has to approve the namespace and select an address for the group. Depending on the permitted namespace, WC client's active address and network may be switched.
- WC provider can not change the address. It can change the network, but the respective WC session will be closed immediately.
- WC clients can change the active address. All such changes would trigger session_update events if the address is in the right group. Otherwise, the session will be closed.
- WC clients may change the network, but the active session will be closed immediately.